### PR TITLE
Register interface driver type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ cfitsio.pc
 testprog
 testprog.lis
 testprog.fit
+vecexample
+vecexample.fit
 
 # Created by https://www.toptal.com/developers/gitignore/api/c,autotools
 # Edit at https://www.toptal.com/developers/gitignore?templates=c,autotools

--- a/fitsio.h
+++ b/fitsio.h
@@ -795,6 +795,14 @@ int CFITS_API ffdkinit(fitsfile** fptr, const char* filename, int* status);
 int CFITS_API ffimem(fitsfile** fptr, void** buffptr, size_t* buffsize,
                      size_t deltasize, void* (*mem_realloc)(void* p, size_t newsize),
                      int* status);
+int CFITS_API
+ffiusr(fitsfile** fptr, int (*init)(void* userp),
+       int (*truncate)(LONGLONG filesize, void* userp), int (*close)(void* userp),
+       int (*size)(LONGLONG* sizex, void* userp), int (*flush)(void* userp),
+       int (*seek)(LONGLONG offset, LONGLONG* result, void* userp),
+       int (*read)(void* buffer, long nbytes, LONGLONG* offset, void* userp),
+       int (*write)(void* buffer, long nbytes, LONGLONG* offset, void* userp),
+       void* userp, int* status);
 int CFITS_API fftplt(fitsfile** fptr, const char* filename, const char* tempname,
                      int* status);
 int CFITS_API ffflus(fitsfile* fptr, int* status);

--- a/fitsio2.h
+++ b/fitsio2.h
@@ -1121,7 +1121,22 @@ int stream_read(int driverhandle, void* buffer, long nbytes);
 int stream_write(int driverhandle, void* buffer, long nbytes);
 
 /* memory driver I/O routines */
-
+int user_openusr(int (*init)(void* userp),
+                 int (*truncate)(LONGLONG filesize, void* userp),
+                 int (*close)(void* userp), int (*size)(LONGLONG* sizex, void* userp),
+                 int (*flush)(void* userp),
+                 int (*seek)(LONGLONG offset, LONGLONG* result, void* userp),
+                 int (*read)(void* buffer, long nbytes, LONGLONG* offset, void* userp),
+                 int (*write)(void* buffer, long nbytes, LONGLONG* offset, void* userp),
+                 void* userp, int* handle);
+int user_init(void);
+int user_truncate(int driverhandle, LONGLONG filesize);
+int user_close(int driverhandle);
+int user_size(int driverhandle, LONGLONG* sizex);
+int user_flush(int driverhandle);
+int user_seek(int driverhandle, LONGLONG offset);
+int user_read(int driverhandle, void* buffer, long nbytes);
+int user_write(int driverhandle, void* buffer, long nbytes);
 int mem_init(void);
 int mem_setoptions(int options);
 int mem_getoptions(int* options);

--- a/longnam.h
+++ b/longnam.h
@@ -30,6 +30,7 @@
 #define fits_create_file ffinit
 #define fits_create_diskfile ffdkinit
 #define fits_create_memfile ffimem
+#define fits_create_userfile ffiusr
 #define fits_create_template fftplt
 #define fits_flush_file ffflus
 #define fits_flush_buffer ffflsh

--- a/vecexample.cxx
+++ b/vecexample.cxx
@@ -1,0 +1,66 @@
+#include <vector>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+
+#include "fitsio.h"
+
+typedef std::vector<char*> fits_vector;
+
+int writevecimage();
+
+int main() {
+    int status;
+    status = writevecimage();
+    fits_report_error(stderr, status);
+    return status;
+}
+
+int vector_truncate(LONGLONG filesize, void* userp) {
+    auto vector = static_cast<fits_vector*>(userp);
+    vector->resize(filesize);
+    return 0;
+}
+
+int vector_size(LONGLONG* sizex, void* userp) {
+    auto vector = static_cast<fits_vector*>(userp);
+    *sizex = static_cast<LONGLONG>(vector->size());
+    return 0;
+}
+
+int vector_read(void* buffer, long nbytes, LONGLONG* offset, void* userp) {
+    auto vector = static_cast<fits_vector*>(userp);
+    if (*offset + nbytes > vector->size()) return (END_OF_FILE);
+    memcpy(buffer, vector->data() + *offset, nbytes);
+    *offset += nbytes;
+    return 0;
+}
+
+int vector_write(void* buffer, long nbytes, LONGLONG* offset, void* userp) {
+    auto vector = static_cast<fits_vector*>(userp);
+    if ((size_t)(*offset + nbytes) > vector->size())
+        vector->resize((((*offset + nbytes - 1) / 2880) + 1) * 2880);
+    memcpy(vector->data() + *offset, buffer, nbytes);
+    *offset += nbytes;
+    return (0);
+}
+
+int writevecimage() {
+    fitsfile* fptr = NULL;
+    int status = 0;
+    long naxes[2] = {300, 200};
+
+    std::vector<char> buffer;
+    fits_create_userfile(&fptr, nullptr, vector_truncate, nullptr, vector_size, nullptr,
+                         nullptr, vector_read, vector_write,
+                         static_cast<void*>(&buffer), &status);
+    fits_create_img(fptr, USHORT_IMG, sizeof(naxes) / sizeof(long), naxes, &status);
+    fits_close_file(fptr, &status);
+
+    std::fstream fout;
+    fout.open("vecexample.fit", std::ios::binary | std::ios::out);
+    fout.write(buffer.data(), buffer.size());
+    fout.close();
+
+    return status;
+}


### PR DESCRIPTION
* Add new driver type "userdef://". This driver requires the client to
  specify custom truncate, close, size, flush, seek, read, and write
  functions.
* Update MAX_DRIVERS to allot space for new driver type.
* Add userdriver data structure, which is used as an interface for core
  FITS I/O functions. Also included is a void* field where clients can
  retain any object they need for I/O operations.
* Add userTable array, which serves a similar purpose to memTable.
* Create ffiusr (fits_create_userfile) function. This function is
  modeled after fits_create_memfile, the primary difference between is
  the driver handle is created with the `user_openusr` function instead
  of `mem_openmem`.
* Add vecexample.cxx, which demonstrates how to use fits_create_userfile
  to place a FITS file in a C++ object like std::vector.